### PR TITLE
Changes customer facing description to a more "friendly" description.

### DIFF
--- a/includes/languages/english/modules/shipping/fedexrest.php
+++ b/includes/languages/english/modules/shipping/fedexrest.php
@@ -1,6 +1,7 @@
 <?php
 // Language file for FedEx REST API 
-define('MODULE_SHIPPING_FEDEX_REST_TEXT_TITLE', 'FedEx REST API');
+define('MODULE_SHIPPING_FEDEX_REST_TEXT_TITLE', 'FedEx REST API'); // For admin side
+define('MODULE_SHIPPING_FEDEX_TEXT_TITLE', 'FedEx'); // For customer side.
 define('MODULE_SHIPPING_FEDEX_REST_TEXT_DESCRIPTION', '<h2>FedEx REST API</h2><p>You will need to have registered an account with FedEx to use this module. Please see the README.TXT file.</p>');
 
 // For locales other than en_US please see 

--- a/includes/modules/shipping/fedexrest.php
+++ b/includes/modules/shipping/fedexrest.php
@@ -89,9 +89,9 @@
          $this->title = MODULE_SHIPPING_FEDEX_REST_TEXT_TITLE;
 
          if (IS_ADMIN_FLAG === true) {
-            $this->title .= ' v' . $this->moduleVersion;
+            $this->title = MODULE_SHIPPING_FEDEX_REST_TEXT_TITLE . ' v' . $this->moduleVersion;
          }
-         $this->description = MODULE_SHIPPING_FEDEX_REST_TEXT_DESCRIPTION;
+         $this->description = MODULE_SHIPPING_FEDEX_TEXT_TITLE;
          $this->sort_order = defined('MODULE_SHIPPING_FEDEX_REST_SORT_ORDER') ? MODULE_SHIPPING_FEDEX_REST_SORT_ORDER : null;
          if (null === $this->sort_order) return false;
          $this->icon = '';


### PR DESCRIPTION
Adds one more define in the language file for the module to show customers a more "friendly" description of the returned rates. 

Will show, for example, "FedEx First Overnight (Saturday)" on Shipping Estimator instead of "FedEx REST API 1.0 First Overnight (Saturday)". The module will maintain its "proper" name in the backend.