### PR TITLE
Disable when only free shipping items are present

### DIFF
--- a/includes/modules/shipping/fedexrest.php
+++ b/includes/modules/shipping/fedexrest.php
@@ -138,6 +138,12 @@
                $this->enabled = false;
             }
          }
+        
+         // disable only when entire cart is free shipping
+         if (!zen_get_shipping_enabled($this->code)) {
+             $this->enabled = false;
+         }
+        
          if ($this->enabled === true && $this->getOAuthToken() === false) {
             $this->enabled = false;
          }


### PR DESCRIPTION
This is present on all the other modules, figured it should be present here too. (I noticed the module was still present and active when "Free Shipping" was present.)